### PR TITLE
Fix issue in sub-directory check in TarIndex

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/tar/TarIndex.java
+++ b/src/main/java/org/apache/hadoop/fs/tar/TarIndex.java
@@ -100,7 +100,7 @@ public class TarIndex {
         TarArchiveEntry entry = new TarArchiveEntry(buffer);
 
         // Index only normal files. Do not support directories yet.
-        if (entry.isFile()) {
+        if (entry.isFile() && !entry.isDirectory()) {
           String name = entry.getName().trim();
           if (!name.equals("")) {
             IndexEntry ie = new IndexEntry(entry.getSize(), currOffset);


### PR DESCRIPTION
The TarIndex component of TarFileSystem does not yet support
directories. So while creating index, the directory entries are skipped.
The check for directory previously was `entry.isFile()` but that does
not work in all cases.

It was observed that for the directory entries both
`entry.isDirectory()` and `entry.isFile()` was true. So, changed the
directory check in TarIndex to check for both isFile and isDirectory.

This should fix the `StackOverflowError` seen in https://github.com/JDatta/TarFileSystem/issues/6